### PR TITLE
chore: upgrade to dart 3

### DIFF
--- a/lib/src/ssh_algorithm.dart
+++ b/lib/src/ssh_algorithm.dart
@@ -3,7 +3,7 @@ import 'package:dartssh2/src/algorithm/ssh_hostkey_type.dart';
 import 'package:dartssh2/src/algorithm/ssh_kex_type.dart';
 import 'package:dartssh2/src/algorithm/ssh_mac_type.dart';
 
-abstract class SSHAlgorithm {
+mixin SSHAlgorithm {
   /// The name of the algorithm.
   String get name;
 

--- a/lib/src/ssh_key_pair.dart
+++ b/lib/src/ssh_key_pair.dart
@@ -663,15 +663,15 @@ class RsaPrivateKey implements SSHKeyPair {
     final coefficient = (sequence.elements[8] as ASN1Integer).valueAsBigInteger;
 
     return RsaPrivateKey(
-      version!,
-      n!,
-      e!,
-      d!,
-      p!,
-      q!,
-      exponent1!,
-      exponent2!,
-      coefficient!,
+      version,
+      n,
+      e,
+      d,
+      p,
+      q,
+      exponent1,
+      exponent2,
+      coefficient,
     );
   }
 

--- a/lib/src/ssh_key_pair.dart
+++ b/lib/src/ssh_key_pair.dart
@@ -273,7 +273,7 @@ class OpenSSHBcryptKdfOptions implements OpenSSHKdfOptions {
   }
 }
 
-abstract class OpenSSHKeyPair implements SSHKeyPair {
+mixin OpenSSHKeyPair implements SSHKeyPair {
   void writeTo(SSHMessageWriter writer);
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 2.9.1-pre
+version: 2.9.1-atsignfork
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/TerminalStudio/dartssh2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: SSH and SFTP client written in pure Dart, aiming to be feature-rich
 homepage: https://github.com/TerminalStudio/dartssh2
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   asn1lib: ^1.0.0


### PR DESCRIPTION
**- What I did**
- chore: remove usage of unnecessary `!` operator in ssh_key_pair.dart
- build: Change required SDK to 3.0.0 or later
- fix: As per https://dart.dev/resources/dart-3-migration#mixin, SSHAlgorithm and OpenSSHKeyPair now need to be declared as mixins in order to be used as mixins using the `with` operator

**- How I did it**

**- How to verify it**
- Can't run unit tests due to external resource (honeypot.terminal.studio) which is unavailable
- Instead verifying via the checks run for [this NoPorts PR](https://github.com/atsign-foundation/noports/pull/1049)