### PR TITLE
fix: ssh_pem carriage return bug

### DIFF
--- a/lib/src/ssh_pem.dart
+++ b/lib/src/ssh_pem.dart
@@ -16,7 +16,7 @@ class SSHPem {
   static const _pemEnd = '-----';
 
   factory SSHPem.decode(String pem) {
-    final lines = pem.trim().split("\n");
+    final lines = pem.trim().split(RegExp(r"\r?\n"));
     final header = lines.first;
     final footer = lines.last;
 


### PR DESCRIPTION
**- What I did**
 sshnp was failing with rsa keys generated from azure using `--ssh-algorithm ssh-rsa`. 
 looks like azure is CRLF.
  
**- How I did it**
 added a regex for the split with an optional \r
 
**- How to verify it**
 Tests passing
**- Description for the changelog**
fix: ssh_pem carriage return bug
