### PR TITLE
build(deps): Bump pinenacl to ^0.6.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartssh2
-version: 2.9.1-atsignfork
+version: 2.9.1-atsignfork-1
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/TerminalStudio/dartssh2
 
@@ -11,7 +11,7 @@ dependencies:
   convert: ^3.0.0
   meta: ^1.1.6
   pointycastle: ^3.0.0
-  pinenacl: ^0.5.0
+  pinenacl: ^0.6.0
 
 dev_dependencies:
   build_runner: ^2.1.1


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/noports/issues/1246

**- What I did**

* Bump pinenacl to ^0.6.0
* Bump version to reflect another change

**- How to verify it**

Run unit tests for noports_core using Dart 3.5.0

**- Description for the changelog**

build(deps): Bump pinenacl to ^0.6.0
